### PR TITLE
Add gomplate to sdtd base image

### DIFF
--- a/images/sdtd-base/Dockerfile
+++ b/images/sdtd-base/Dockerfile
@@ -1,6 +1,9 @@
 FROM joshhsoj1902/docker-linuxgsm-scripts:1.2.0 AS scripts
+FROM hairyhenderson/gomplate:v3.11.5 AS gomplate
+
 FROM gameservermanagers/gameserver:sdtd
 
+COPY --from=gomplate /gomplate /bin/gomplate
 # Install envsubt
 RUN apt-get update && apt-get install -y \
     gettext-base \


### PR DESCRIPTION
Go templating is a lot more flexible than `envsubt`, especially when a config line should be completely excluded if an env isn't set.

So instead I want to pull in [gomplate](https://github.com/hairyhenderson/gomplate) and try using that instead.  

For now I'm only pulling it into sdtd since I'm working on that, but if it works I may look at rolling it out everywhere.