### PR TITLE
Fix tag release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,18 @@ workflows:
           filters:
             branches:
               only: main
+  tag-release:
+    jobs:
+      - build-docker:
+          name: build << matrix.dir >>
+          matrix:
+            parameters:
+              dir: *images
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish-docker-tag:
           name: publish tag << matrix.dir >>
           matrix:


### PR DESCRIPTION
CCI wouldn't trigger the tag release job because the "build" step had already ran for that git sha.

By duplicating the build step I think that solves it. 