### PR TITLE
7dtd / Add DeathPenalty

### DIFF
--- a/images/sdtd-base/layers/001-base/serverfiles/sdtdserver.xml.gomplate
+++ b/images/sdtd-base/layers/001-base/serverfiles/sdtdserver.xml.gomplate
@@ -125,6 +125,8 @@
 	<property name="DayNightLength"	value="{{getenv "LGSM_DAY_NIGHT_LENGTH" "60"}}" />				<!-- real time minutes per in game day: 60 minutes -->
 	<property name="DayLightLength" value="{{getenv "LGSM_DAY_LIGHT_LENGTH" "18"}}" />				<!-- in game hours the sun shines per day: 18 hours
 	day light per in game day -->
+	<property name="DeathPenalty" value="{{getenv "LGSM_DEATH_PENALTY" "1"}}" />				<!-- Penalty after dying. 0 = Nothing. 1 = Default: Classic XP Penalty.  2 = Injured: You keep most of your debuffs. Food and Water is set to 50% on respawn. 3 = Permanent Death: Your character is completely reset. You will respawn with a fresh start within the saved game. -->
+
 	<property name="DropOnDeath" value="{{getenv "LGSM_DROP_ON_DEATH" "1"}}" />				<!-- 0 = nothing, 1 = everything, 2 = toolbelt only, 3 =
 	backpack only, 4 = delete all -->
 	<property name="DropOnQuit" value="{{getenv "LGSM_DROP_ON_QUIT" "0"}}" />				<!-- 0 = nothing, 1 = everything, 2 = toolbelt only, 3 =


### PR DESCRIPTION
This is blocked by: https://github.com/GameServerManagers/Game-Server-Configs/pull/139

I have tests in place to validate that the 7dtd config aligns with the defaults the LGSM sets, but because this setting is missing from that config currently the tests will always fail. 