### PR TITLE
Force java upgrade to support latest paper version

### DIFF
--- a/images/minecraft-paper-base/Dockerfile
+++ b/images/minecraft-paper-base/Dockerfile
@@ -3,6 +3,10 @@ FROM hairyhenderson/gomplate:v3.11.7 AS gomplate
 
 FROM gameservermanagers/gameserver:pmc@sha256:896e1c745e691d6d9ad95f574c3af260d89056a0e4e8e9d2bd716b45b5e7526d
 
+# Upgrade java version (remove this if the base image is updated)
+RUN apt-get update && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # Override entrypoint-user to support hooks
 COPY --from=scripts /entrypoint-user.sh /app/entrypoint-user.sh
 COPY --from=gomplate /gomplate /bin/gomplate

--- a/images/minecraft-paper-base/Dockerfile
+++ b/images/minecraft-paper-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM joshhsoj1902/docker-linuxgsm-scripts:1.4.0 AS scripts
+FROM joshhsoj1902/docker-linuxgsm-scripts:1.5.0 AS scripts
 FROM hairyhenderson/gomplate:v3.11.7 AS gomplate
 
 FROM gameservermanagers/gameserver:pmc@sha256:896e1c745e691d6d9ad95f574c3af260d89056a0e4e8e9d2bd716b45b5e7526d

--- a/images/minecraft-paper-base/Dockerfile
+++ b/images/minecraft-paper-base/Dockerfile
@@ -4,7 +4,7 @@ FROM hairyhenderson/gomplate:v3.11.7 AS gomplate
 FROM gameservermanagers/gameserver:pmc@sha256:896e1c745e691d6d9ad95f574c3af260d89056a0e4e8e9d2bd716b45b5e7526d
 
 # Upgrade java version (remove this if the base image is updated)
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update && sudo apt install openjdk-21-jdk -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Override entrypoint-user to support hooks


### PR DESCRIPTION
It looks like the new versions of minecraft need a newer Java version

https://github.com/itzg/docker-minecraft-server/issues/2808

