### PR TITLE
[L4D2] Support adding admins

### DIFF
--- a/images/l4d2-8coop/layers/001-base/serverfiles/left4dead2/addons/sourcemod/configs/admins_simple.ini.gomplate
+++ b/images/l4d2-8coop/layers/001-base/serverfiles/left4dead2/addons/sourcemod/configs/admins_simple.ini.gomplate
@@ -42,3 +42,8 @@
 //   "BAILOPAN"			"abc"	"Gab3n"		//name BAILOPAN, password "Gab3n": gets reservation, generic, kick
 //
 ////////////////////////////////
+{{ if env.Getenv "LGSM_L4D2_ADMIN_LIST" }}
+{{- range (getenv "LGSM_L4D2_ADMIN_LIST" | strings.Split ",") }}
+"{{.}}" "@Full Admins"
+{{- end}}
+{{ end }}


### PR DESCRIPTION
By setting the env var `LGSM_L4D2_ADMIN_LIST` Any of the steam users listed will be made sourcemod admins

```
    environment:
      - LGSM_L4D2_ADMIN_LIST=STEAM_1:0:1,STEAM_1:0:2,STEAM_1:0:3
```