### PR TITLE
[l4d2] Add discord logging plugin to log game actions to a discord server

### DIFF
--- a/images/l4d2-8coop/Dockerfile
+++ b/images/l4d2-8coop/Dockerfile
@@ -40,6 +40,10 @@ FROM ubuntu AS sourcescramble
 ADD https://github.com/nosoop/SMExt-SourceScramble/releases/download/0.7.1.4/package.tar.gz package.tar.gz
 RUN tar -zxvf package.tar.gz
 
+# Discord logger
+FROM bitnami/git AS discord
+RUN git clone https://github.com/Mbk10201/Discord_loggerv2.git
+
 FROM gameservermanagers/gameserver:l4d2
 ARG IMAGE_DIR
 
@@ -64,6 +68,8 @@ COPY --from=l4dplugins /L4D1_2-Plugins/l4dmultislots /layers/l4dtoolz/serverfile
 COPY --from=l4dplugins /L4D1_2-Plugins/l4dafkfix_deadbot /layers/l4dtoolz/serverfiles/left4dead2/addons/sourcemod
 
 COPY --from=l4d2plugins /L4D2-Plugins/lfd_both_fixUpgradePack /layers/l4dtoolz/serverfiles/left4dead2/addons/sourcemod
+
+COPY --from=discord /Discord_loggerv2/ /layers/discordlogger/serverfiles/left4dead2/addons/sourcemod
 
 COPY --from=left4fix ["/Left-4-fix/left 4 fix/Defib_Fix", "/layers/l4dtoolz/serverfiles/left4dead2/addons/sourcemod"]
 COPY --from=left4fix ["/Left-4-fix/left 4 fix/survivors/survivor_afk_fix", "/layers/l4dtoolz/serverfiles/left4dead2/addons/sourcemod"]

--- a/images/l4d2-8coop/layers/60-discord-logger/Readme.md
+++ b/images/l4d2-8coop/layers/60-discord-logger/Readme.md
@@ -1,0 +1,3 @@
+https://forums.alliedmods.net/showthread.php?t=336415&highlight=discord
+
+https://github.com/Mbk10201/Discord_loggerv2

--- a/images/l4d2-8coop/layers/60-discord-logger/serverfiles/left4dead2/addons/sourcemod/configs/discord_logger.ini.gomplate
+++ b/images/l4d2-8coop/layers/60-discord-logger/serverfiles/left4dead2/addons/sourcemod/configs/discord_logger.ini.gomplate
@@ -1,0 +1,83 @@
+"Discord_logger"
+{
+	"settings"
+	{
+		"username"		"Sourcemod logger"
+		"title_link"	"https://sourcemod.net/"
+		"log_ip"		"0"
+		"log_fakeplayers"	"1"
+		"log_steamid"	"1"
+		"log_country"	"1"
+		"log_ipconnect"	"1"
+		"embed"		"1"
+		"informations_timer"	"360.0"
+
+		"auth"
+		{
+			"enabled"	"1"
+			"channel"	"public"
+			"tag"		""
+		}
+		"map"
+		{
+			"enabled"	"1"
+			"channel"	"public"
+			"tag"		""
+		}
+		"bans"
+		{
+			"enabled"	"1"
+			"channel"	"private"
+			"tag"		"@here"
+		}
+		"kick"
+		{
+			"enabled"	"1"
+			"channel"	"private"
+			"tag"		"@here"
+		}
+		"chat"
+		{
+			"enabled"	"1"
+			"channel"	"public"
+			"tag"		""
+		}
+		"gag"
+		{
+			"enabled"	"1"
+			"channel"	"private"
+			"tag"		"@here"
+		}
+		"kill"
+		{
+			"enabled"	"0"
+			"channel"	"public"
+			"tag"		""
+		}
+		"informations"
+		{
+			"enabled"	"1"
+			"channel"	"public"
+			"tag"		""
+		}
+		"roundend_playersalive"
+		{
+			"enabled"	"1"
+			"channel"	"public"
+			"tag"		""
+		}
+	}
+	"webhooks"
+	{
+		"public"
+		{
+			"color"	"#0EA2D1"
+			"url"		"{{getenv "LGSM_DISCORD_LOGGING_WEBHOOK"}}"
+		}
+		"private"
+		{
+			"color"	"#0EA2D1"
+			"url"		"{{getenv "LGSM_DISCORD_LOGGING_WEBHOOK"}}"
+		}
+	}
+}


### PR DESCRIPTION
This is hacky and likely shouldn't be bundled in this image, but as is I'm the only one using this image, so it's fine for now...

This adds a plugin which if the env var `LGSM_DISCORD_LOGGING_WEBHOOK` is set with a valid discord webhook it'll log various game events to that channel.

If that webhook isn't supplied it'll log some errors to the logfile but the server will still work.