### PR TITLE
Disable L4D2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ define:
     sdtd-base,
     sdtd-a19,
     sdtd-a21,
-    l4d2-base,
-    l4d2-8coop,
+    # l4d2-base,
+    # l4d2-8coop,
   ]
 
 executors:


### PR DESCRIPTION
Disable L4D2 while we wait to find why Valve broke it and if there is a viable workaround.

https://discordapp.com/channels/127498813903601664/353984904297578496/1311779302899187713

https://github.com/ValveSoftware/steam-for-linux/issues/11522

Maybe

https://github.com/ValveSoftware/steam-for-linux/issues/11459